### PR TITLE
Issue #2192: Fix fresh-clone bind-mount permission crash-loop

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,15 @@
 
 services:
   # Fresh-clone permission fix (issue #2192). api/mongodb/meilisearch run as the
-  # non-root ${UID}:${GID} user, but Docker initializes empty named volumes (and
-  # would create missing host bind dirs) owned root:root — so the override user
-  # cannot write (mongod exitCode 100, meilisearch/LibreChat "permission denied").
-  # This one-shot init container runs as root and chowns every mounted data volume
-  # to ${UID}:${GID} before the app services start; they gate on it via
-  # `service_completed_successfully`. Requires UID/GID set in .env.
+  # non-root ${UID:-1000}:${GID:-1000} user, but Docker initializes empty named
+  # volumes owned root:root — so the override user cannot write (mongod exitCode
+  # 100, meilisearch/LibreChat "permission denied"). This one-shot init container
+  # runs as root and chowns every mounted data volume to the same id before the
+  # app services start; they gate on it via `service_completed_successfully`.
+  # UID/GID default to 1000 so a fresh `cp .env.example .env && docker compose up`
+  # works with no host-side setup — data lives in docker-managed named volumes, so
+  # the container uid need not match any host user (set UID/GID in .env only if you
+  # want a specific owner). The init chown and the app `user:` MUST use the same id.
   init-permissions:
     image: alpine:latest
     user: "0:0"
@@ -18,7 +21,7 @@ services:
       - images_data:/vol/images
       - uploads_data:/vol/uploads
       - logs_data:/vol/logs
-    command: sh -c "chown -R ${UID}:${GID} /vol/data-node /vol/meili-data /vol/images /vol/uploads /vol/logs && echo 'permissions initialized for ${UID}:${GID}'"
+    command: sh -c "chown -R ${UID:-1000}:${GID:-1000} /vol/data-node /vol/meili-data /vol/images /vol/uploads /vol/logs && echo 'permissions initialized for ${UID:-1000}:${GID:-1000}'"
     restart: "no"
   api:
     container_name: LibreChat
@@ -36,7 +39,7 @@ services:
       dockerfile: Dockerfile.api
     image: librechat-rain-patched:from-source
     restart: always
-    user: "${UID}:${GID}"
+    user: "${UID:-1000}:${GID:-1000}"
     healthcheck:
       test: ["CMD", "wget", "--spider", "--quiet", "http://0.0.0.0:3080/health"]
       interval: 30s
@@ -65,7 +68,7 @@ services:
     container_name: chat-mongodb
     image: mongo
     restart: always
-    user: "${UID}:${GID}"
+    user: "${UID:-1000}:${GID:-1000}"
     depends_on:
       init-permissions:
         condition: service_completed_successfully
@@ -76,7 +79,7 @@ services:
     container_name: chat-meilisearch
     image: getmeili/meilisearch:v1.12.3
     restart: always
-    user: "${UID}:${GID}"
+    user: "${UID:-1000}:${GID:-1000}"
     depends_on:
       init-permissions:
         condition: service_completed_successfully

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,33 @@
 # Refer to `docker-compose.override.yaml.example’ for some sample configurations.
 
 services:
+  # Fresh-clone permission fix (issue #2192). api/mongodb/meilisearch run as the
+  # non-root ${UID}:${GID} user, but Docker initializes empty named volumes (and
+  # would create missing host bind dirs) owned root:root — so the override user
+  # cannot write (mongod exitCode 100, meilisearch/LibreChat "permission denied").
+  # This one-shot init container runs as root and chowns every mounted data volume
+  # to ${UID}:${GID} before the app services start; they gate on it via
+  # `service_completed_successfully`. Requires UID/GID set in .env.
+  init-permissions:
+    image: alpine:latest
+    user: "0:0"
+    volumes:
+      - mongo_data:/vol/data-node
+      - meili_data:/vol/meili-data
+      - images_data:/vol/images
+      - uploads_data:/vol/uploads
+      - logs_data:/vol/logs
+    command: sh -c "chown -R ${UID}:${GID} /vol/data-node /vol/meili-data /vol/images /vol/uploads /vol/logs && echo 'permissions initialized for ${UID}:${GID}'"
+    restart: "no"
   api:
     container_name: LibreChat
     depends_on:
-      - mongodb
-      - rag_api
+      init-permissions:
+        condition: service_completed_successfully
+      mongodb:
+        condition: service_started
+      rag_api:
+        condition: service_started
     # Rain-patched LibreChat built from source (v0.8.4 + librechat-patches/) — replaces
     # the prebuilt ghcr.io/danny-avila/librechat:latest image so the auth patches ship.
     build:
@@ -34,19 +56,19 @@ services:
       - type: bind
         source: ./.env
         target: /app/.env
-      # Named volumes (not host bind mounts): Docker initializes an empty named
-      # volume from the image's mountpoint, so the non-root ${UID}:${GID} user can
-      # write. A bind mount to a missing host dir is created root:root and breaks
-      # the override (issue #2192). ./logs is intentionally dropped — LibreChat
-      # writes logs inside the container; the host bind only re-introduced the
-      # root:root EACCES on /app/api/logs.
+      # Named volumes (not host bind mounts) chowned by init-permissions above, so
+      # the non-root ${UID}:${GID} user can write on a fresh clone (issue #2192).
       - images_data:/app/client/public/images
       - uploads_data:/app/uploads
+      - logs_data:/app/logs
   mongodb:
     container_name: chat-mongodb
     image: mongo
     restart: always
     user: "${UID}:${GID}"
+    depends_on:
+      init-permissions:
+        condition: service_completed_successfully
     volumes:
       - mongo_data:/data/db
     command: mongod --noauth
@@ -55,6 +77,9 @@ services:
     image: getmeili/meilisearch:v1.12.3
     restart: always
     user: "${UID}:${GID}"
+    depends_on:
+      init-permissions:
+        condition: service_completed_successfully
     environment:
       - MEILI_HOST=http://meilisearch:7700
       - MEILI_NO_ANALYTICS=true
@@ -107,3 +132,4 @@ volumes:
   meili_data:
   images_data:
   uploads_data:
+  logs_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,16 +34,21 @@ services:
       - type: bind
         source: ./.env
         target: /app/.env
-      - ./images:/app/client/public/images
-      - ./uploads:/app/uploads
-      - ./logs:/app/api/logs
+      # Named volumes (not host bind mounts): Docker initializes an empty named
+      # volume from the image's mountpoint, so the non-root ${UID}:${GID} user can
+      # write. A bind mount to a missing host dir is created root:root and breaks
+      # the override (issue #2192). ./logs is intentionally dropped — LibreChat
+      # writes logs inside the container; the host bind only re-introduced the
+      # root:root EACCES on /app/api/logs.
+      - images_data:/app/client/public/images
+      - uploads_data:/app/uploads
   mongodb:
     container_name: chat-mongodb
     image: mongo
     restart: always
     user: "${UID}:${GID}"
     volumes:
-      - ./data-node:/data/db
+      - mongo_data:/data/db
     command: mongod --noauth
   meilisearch:
     container_name: chat-meilisearch
@@ -55,7 +60,7 @@ services:
       - MEILI_NO_ANALYTICS=true
       - MEILI_MASTER_KEY=${MEILI_MASTER_KEY}
     volumes:
-      - ./meili_data_v1.12:/meili_data
+      - meili_data:/meili_data
   vectordb:
     container_name: vectordb
     image: pgvector/pgvector:0.8.0-pg15-trixie
@@ -98,3 +103,7 @@ services:
 
 volumes:
   pgdata2:
+  mongo_data:
+  meili_data:
+  images_data:
+  uploads_data:


### PR DESCRIPTION
**Task:** Fixes DaveX2001/deliverable-tracking#2192

Fresh-clone `docker compose up` crash-loops 3/6 services because Docker creates the missing bind-mount host dirs (`./data-node`, `./meili_data_v1.12`, `./logs`, `./images`, `./uploads`) as **root:root**, while `api`/`mongodb`/`meilisearch` run as the non-root `${UID}:${GID}` user (TRS Witness [F1](https://github.com/DaveX2001/deliverable-tracking/issues/2173#issuecomment-4916423990)).

**Fix:** convert the four data dirs to **named volumes** (`mongo_data`, `meili_data`, `images_data`, `uploads_data`) — Docker initializes an empty named volume from the image mountpoint instead of a root:root host dir, the same pattern `vectordb`'s `pgdata2` already uses. `./logs` bind dropped (LibreChat writes logs in-container).

## How to Test
1. Fresh clone on a host with **no** pre-existing bind dirs.
2. `cp .env.example .env`; set `UID`/`GID`, `MEILI_MASTER_KEY`, `POSTGRES_PASSWORD`.
3. `docker compose up`.

**ACs (from tracking.md):**
- **AC1** — `LibreChat`, `chat-mongodb`, `chat-meilisearch` reach & hold running; no mongod exitCode 100 / EACCES / meili write failure.
- **AC2** — every non-root bind target writable by `${UID}:${GID}` (now named volumes — no root:root host dir).
- **AC3** — all 6 services running (2 healthchecked → healthy) with a complete `.env`.