### PR TITLE
fix: close client-deployability gaps for turnkey FM Assistant deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,10 @@
 # FM Assistant Environment Variables
 # =============================================================================
 
-# --- Port Overrides (default: 0 = Docker auto-assigns) ---
-# API_PORT=3080
+# --- Port Overrides ---
+# API_PORT: host port the FM Assistant UI is published on
+# (docker-compose.yml maps ${API_PORT}:3080). Change it if 3080 is taken on the host.
+API_PORT=3080
 # FASTMCP_PORT=8000
 
 # --- LibreChat ---
@@ -11,8 +13,13 @@ CREDS_KEY=
 CREDS_IV=
 JWT_SECRET=
 JWT_REFRESH_SECRET=
-DOMAIN_CLIENT=https://archibus-fm-assistant.wilsch-deployment.com
-DOMAIN_SERVER=https://archibus-fm-assistant.wilsch-deployment.com
+# Set these to the client's own host (scheme + host + published port).
+# The default suits a local / single-host deploy reached at http://localhost:${API_PORT}.
+DOMAIN_CLIENT=http://localhost:3080
+DOMAIN_SERVER=http://localhost:3080
+
+# Allow the first user to self-register through the shipped /register path.
+ALLOW_REGISTRATION=true
 
 # --- Search (Meilisearch) ---
 SEARCH=true
@@ -20,8 +27,10 @@ MEILI_MASTER_KEY=
 
 # --- RAG ---
 RAG_PORT=8000
-EMBEDDINGS_PROVIDER=
-EMBEDDINGS_MODEL=
+# Must be a valid EmbeddingsProvider (empty crash-loops rag_api on
+# "ValueError: '' is not a valid EmbeddingsProvider"). Default uses OPENAI_API_KEY below.
+EMBEDDINGS_PROVIDER=openai
+EMBEDDINGS_MODEL=text-embedding-3-small
 
 # --- Vector Database (PostgreSQL + pgvector) ---
 POSTGRES_DB=mydatabase
@@ -46,6 +55,13 @@ USER_API_CLIENT_ID=
 # e.g. https://services.bruceplatform.com/api/  and  https://userauth.bruceplatform.com/api/
 BEM_API_URL=
 USER_AUTH_URL=
+
+# --- Standalone / staging auth (STAGING_MODE) ---
+# Default deploys expect a Rain user-token forwarded from the Bruce BEM iframe.
+# For a standalone deploy with no iframe, set STAGING_MODE=true and fill USERNAME/PASSWORD;
+# archibus_fastmcp then authenticates directly with these BEM credentials instead of the
+# Rain token. See README "Standalone (STAGING_MODE) deployment" and docker-compose.staging.yml.
+STAGING_MODE=false
 USERNAME=
 PASSWORD=
 GRANT_TYPE=client_credentials

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -54,6 +54,9 @@ COPY --chown=node:node librechat-patches/api/server/controllers/agents/client.js
 COPY --chown=node:node librechat-patches/api/server/services/MCP.js api/server/services/MCP.js
 COPY --chown=node:node librechat-patches/api/server/routes/config.js api/server/routes/config.js
 
+# Bruce agent seed script (run once by the init-bruce-agent service in docker-compose.yml)
+COPY --chown=node:node librechat-patches/config/seed-bruce-agent.js config/seed-bruce-agent.js
+
 # Shared packages (TypeScript, compiled during build)
 COPY --chown=node:node librechat-patches/packages/data-provider/src/config.ts packages/data-provider/src/config.ts
 COPY --chown=node:node librechat-patches/packages/data-provider/src/createPayload.ts packages/data-provider/src/createPayload.ts

--- a/README.md
+++ b/README.md
@@ -47,6 +47,49 @@
 </p>
 
 
+# 🚀 FM Assistant deployment
+
+This distribution ships the ARCHIBUS **FM Assistant** (Rain-patched LibreChat + the Bruce
+BEM MCP tool server). A client VM with Docker can bring it up turnkey:
+
+```bash
+git clone https://github.com/veloxforce/archibus-deploy.git
+cd archibus-deploy
+cp .env.example .env
+# Fill the documented secrets in .env: CREDS_KEY/CREDS_IV, JWT_SECRET/JWT_REFRESH_SECRET,
+# MEILI_MASTER_KEY, POSTGRES_PASSWORD, OPENAI_API_KEY (embeddings), and the BEM credentials.
+docker compose up -d
+```
+
+The UI is then published on the host at `http://<host>:${API_PORT}` (default
+`http://localhost:3080`). Set `DOMAIN_CLIENT`/`DOMAIN_SERVER` in `.env` to that same host.
+`ALLOW_REGISTRATION=true` ships by default so you can create the first user at `/register`.
+A **Bruce Facility Management Assistant** agent is seeded automatically on first boot and is
+selectable from the model menu.
+
+## Standalone (STAGING_MODE) deployment
+
+By default the Bruce BEM tools authenticate with a **Rain user-token** forwarded from the
+Bruce BEM iframe. For a **standalone** deployment (no iframe — e.g. a client accessing the
+FM Assistant directly), enable the designed staging auth path instead: the MCP server then
+logs in with the BEM `USERNAME`/`PASSWORD` from `.env`.
+
+1. In `.env`, set `STAGING_MODE=true` and fill `USERNAME` / `PASSWORD` (plus the
+   `OAUTH_*` / `BEM_API_URL` / `USER_AUTH_URL` credentials).
+2. Bring the stack up with the staging overlay:
+
+   ```bash
+   docker compose \
+     -f docker-compose.yml \
+     -f docker-compose.override.yml \
+     -f docker-compose.staging.yml \
+     up -d
+   ```
+
+The `docker-compose.staging.yml` overlay forces `STAGING_MODE=true` on the
+`archibus_fastmcp` service, so a Bruce tool-call (e.g. `search_assets`) completes without
+an iframe Rain token. See issue #602 for the ship-with-confidence staging architecture.
+
 # ✨ Features
 
 - 🖥️ **UI & Experience** inspired by ChatGPT with enhanced design and features

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,0 +1,22 @@
+# Standalone (STAGING_MODE) overlay — issue #602 "ship-with-confidence" staging architecture.
+#
+# The default deploy expects a Rain user-token forwarded from the Bruce BEM iframe; a
+# standalone deployment has no iframe, so archibus_fastmcp's AuthPersistenceMiddleware
+# dead-ends at "Rain user token required...". This overlay flips the MCP server onto its
+# designed standalone auth path: STAGING_MODE=true makes it authenticate directly with the
+# BEM USERNAME/PASSWORD from .env instead of a per-request Rain token.
+#
+# Usage (from a fresh clone, after filling .env incl. BEM USERNAME/PASSWORD):
+#   docker compose \
+#     -f docker-compose.yml \
+#     -f docker-compose.override.yml \
+#     -f docker-compose.staging.yml \
+#     up -d
+#
+# Prerequisite: set STAGING_MODE=true (this overlay also forces it) and fill USERNAME /
+# PASSWORD plus the OAuth/BEM URL vars in .env — see the "Standalone / staging auth"
+# block in .env.example.
+services:
+  archibus_fastmcp:
+    environment:
+      - STAGING_MODE=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
     depends_on:
       init-permissions:
         condition: service_completed_successfully
+      init-bruce-agent:
+        condition: service_completed_successfully
       mongodb:
         condition: service_started
       rag_api:
@@ -40,6 +42,10 @@ services:
     image: librechat-rain-patched:from-source
     restart: always
     user: "${UID:-1000}:${GID:-1000}"
+    # Publish the UI on the host so a naive `docker compose up` is reachable from
+    # outside the docker network. Host port is ${API_PORT} (default 3080) → container 3080.
+    ports:
+      - "${API_PORT:-3080}:3080"
     healthcheck:
       test: ["CMD", "wget", "--spider", "--quiet", "http://0.0.0.0:3080/health"]
       interval: 30s
@@ -54,7 +60,8 @@ services:
       - MEILI_HOST=http://meilisearch:7700
       - RAG_PORT=${RAG_PORT:-8000}
       - RAG_API_URL=http://rag_api:${RAG_PORT:-8000}
-      - DOMAIN_SERVER=https://librechat.veloxforce.dev
+      # Resolve to the client's configured host from .env (no hardcoded Wilsch domain).
+      - DOMAIN_SERVER=${DOMAIN_SERVER:-http://localhost:3080}
     volumes:
       - type: bind
         source: ./.env
@@ -64,6 +71,23 @@ services:
       - images_data:/app/client/public/images
       - uploads_data:/app/uploads
       - logs_data:/app/logs
+  # One-shot seed: create the "Bruce Facility Management Assistant" DB agent
+  # (id agent_PHHeJ7reQRf0eQJwXS2M8, referenced by librechat.yaml's modelSpec) so a
+  # fresh clone has a selectable agent out of the box. Idempotent — exits early if the
+  # agent already exists. Same init-container pattern as init-permissions; the api
+  # service gates on its successful completion.
+  init-bruce-agent:
+    build:
+      context: .
+      dockerfile: Dockerfile.api
+    image: librechat-rain-patched:from-source
+    command: ["node", "config/seed-bruce-agent.js"]
+    restart: "no"
+    environment:
+      - MONGO_URI=mongodb://mongodb:27017/LibreChat
+    depends_on:
+      mongodb:
+        condition: service_started
   mongodb:
     container_name: chat-mongodb
     image: mongo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,6 @@ services:
     depends_on:
       init-permissions:
         condition: service_completed_successfully
-      init-bruce-agent:
-        condition: service_completed_successfully
       mongodb:
         condition: service_started
       rag_api:
@@ -74,8 +72,13 @@ services:
   # One-shot seed: create the "Bruce Facility Management Assistant" DB agent
   # (id agent_PHHeJ7reQRf0eQJwXS2M8, referenced by librechat.yaml's modelSpec) so a
   # fresh clone has a selectable agent out of the box. Idempotent — exits early if the
-  # agent already exists. Same init-container pattern as init-permissions; the api
-  # service gates on its successful completion.
+  # agent already exists.
+  #
+  # Runs AFTER api is healthy (not before): the seed grants the agent public VIEW via
+  # the `agent_viewer` access-role, and that role is seeded by the api service at
+  # startup. Gating the seed on `api: service_healthy` guarantees the role exists when
+  # grantPermission runs — otherwise the share silently fails ("Role agent_viewer not
+  # found") and the agent is created but unselectable by any user (issue #2200 AC4).
   init-bruce-agent:
     build:
       context: .
@@ -88,6 +91,8 @@ services:
     depends_on:
       mongodb:
         condition: service_started
+      api:
+        condition: service_healthy
   mongodb:
     container_name: chat-mongodb
     image: mongo

--- a/librechat-patches/config/seed-bruce-agent.js
+++ b/librechat-patches/config/seed-bruce-agent.js
@@ -1,0 +1,92 @@
+// Seed the "Bruce Facility Management Assistant" agent on a fresh clone.
+//
+// librechat.yaml's modelSpec pins agent_id `agent_PHHeJ7reQRf0eQJwXS2M8`, which is a
+// DB-stored agent that does not exist in a fresh install — so out of the box the
+// distribution points at an agent nobody can select. This one-shot script creates that
+// agent (id preserved, so librechat.yaml needs no change) and grants it public VIEW so
+// every user can chat with it (the modelSpec makes it the default for all users).
+//
+// Idempotent: if the agent already exists it exits 0 without changes, so it is safe to
+// run on every `docker compose up` (see the init-bruce-agent service in docker-compose.yml).
+//
+// Modeled on config/create-user.js — same module-alias + shared connect helper.
+const path = require('path');
+const mongoose = require('mongoose');
+const { User } = require('@librechat/data-schemas').createModels(mongoose);
+require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
+const { getAgent, createAgent } = require('~/models/Agent');
+const connect = require('./connect');
+
+const AGENT_ID = 'agent_PHHeJ7reQRf0eQJwXS2M8';
+
+// MCP tools attach as `${mcp_all}${mcp_delimiter}${server}` — grant the agent every tool
+// exposed by the `bruce-bem` MCP server declared in librechat.yaml.
+const BRUCE_TOOLS = ['sys__all__sys_mcp_bruce-bem'];
+
+const INSTRUCTIONS = [
+  'You are Bruce, a Facility Management Assistant for ARCHIBUS / Bruce BEM.',
+  'Use the Bruce BEM tools to answer questions about facilities, assets, work orders,',
+  'and space. Prefer a tool call over guessing; report the live data you retrieve.',
+].join(' ');
+
+(async () => {
+  await connect();
+
+  // Idempotency guard — bail out if the pinned agent already exists.
+  const existing = await getAgent({ id: AGENT_ID });
+  if (existing) {
+    console.log(`[seed-bruce-agent] Agent ${AGENT_ID} already exists — nothing to do.`);
+    return process.exit(0);
+  }
+
+  // The agent needs an author (User ref). Reuse the first existing user if any (the
+  // client's first registered account), else synthesize a stable system-owner id — the
+  // Mongoose ref is not FK-enforced, and public VIEW below is what makes it usable.
+  const firstUser = await User.findOne({}).sort({ createdAt: 1 }).lean();
+  const authorId = firstUser ? firstUser._id : new mongoose.Types.ObjectId();
+
+  await createAgent({
+    id: AGENT_ID,
+    name: 'Bruce Facility Management Assistant',
+    description: 'FM Assistant backed by the Bruce BEM tools.',
+    // provider must match a configured endpoint in librechat.yaml (custom "OpenRouter").
+    provider: 'OpenRouter',
+    model: 'anthropic/claude-sonnet-4.6',
+    instructions: INSTRUCTIONS,
+    tools: BRUCE_TOOLS,
+    author: authorId,
+    authorName: 'System',
+  });
+  console.log(`[seed-bruce-agent] Created agent ${AGENT_ID}.`);
+
+  // Make the agent usable by every user (the modelSpec sets it as the default for all).
+  // Best-effort: the PermissionService API surface differs across LibreChat versions, so
+  // failure here must not fail the seed — the agent still exists and is owner-usable.
+  try {
+    const created = await getAgent({ id: AGENT_ID });
+    const { grantPermission } = require('~/server/services/PermissionService');
+    const {
+      PrincipalType,
+      ResourceType,
+      AccessRoleIds,
+    } = require('librechat-data-provider');
+    await grantPermission({
+      principalType: PrincipalType.PUBLIC,
+      principalId: null,
+      resourceType: ResourceType.AGENT,
+      resourceId: created._id,
+      accessRoleId: AccessRoleIds.AGENT_VIEWER,
+    });
+    console.log('[seed-bruce-agent] Granted public VIEW on the agent.');
+  } catch (err) {
+    console.warn(
+      `[seed-bruce-agent] Could not grant public VIEW (${err.message}); ` +
+        'agent created but may need a manual share.',
+    );
+  }
+
+  process.exit(0);
+})().catch((err) => {
+  console.error(`[seed-bruce-agent] Seed failed: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

Closes the five packaging/documentation gaps between a naive `cp .env.example .env && docker compose up` and a working end-to-end FM Assistant on a client VM — surfaced by the [#2173](https://github.com/DaveX2001/deliverable-tracking/issues/2173) TRS witness. No architecture rework; the Bruce capability is already proven live.

## Fixes (mapped to the AC walk boot → reach + first user → Bruce end-to-end)

- **AC1 — boot 6/6:** `.env.example` ships `EMBEDDINGS_PROVIDER=openai` (+ `EMBEDDINGS_MODEL`) so `rag_api` no longer crash-loops on the empty enum.
- **AC2 — reachable UI:** base `docker-compose.yml` `api` now publishes `${API_PORT:-3080}:3080`; the hardcoded Wilsch `DOMAIN_SERVER` is replaced with `${DOMAIN_SERVER}`; `.env.example` domains default to `http://localhost:3080`.
- **AC3 — first user:** `.env.example` ships `ALLOW_REGISTRATION=true`.
- **AC4 — seeded Bruce agent:** a one-shot `init-bruce-agent` container seeds the "Bruce Facility Management Assistant" agent (`config/seed-bruce-agent.js`, shipped via `Dockerfile.api` COPY, gated by the `api` service). The pinned `agent_id` is preserved, so `librechat.yaml` is unchanged. Config-defined agents were ruled out (structurally unsupported in LibreChat); the api image builds from a source tarball + `librechat-patches/` overlay, so the seed goes through that channel.
- **AC5 — standalone STAGING_MODE:** signposted in `.env.example` + a README "Standalone (STAGING_MODE) deployment" section + a new `docker-compose.staging.yml` overlay (per [#602](https://github.com/DaveX2001/deliverable-tracking/issues/602)).

## Notes

- Docker was not booted in this change; runtime verification is the [#2200](https://github.com/DaveX2001/deliverable-tracking/issues/2200) re-witness (borrowed live BEM creds).

Refs DaveX2001/deliverable-tracking#2200

🤖 Generated with [Claude Code](https://claude.com/claude-code)